### PR TITLE
Docker Compose -> Tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 - As new items come up, add to [TODO](./TODO.md). 
 
 ## Setup
-Run `docker-compose up`
+Run `tilt up`
+ 
+Or run `docker-compose up`
 
 ## Services: 
 - [Web Frontend Service](./services/web-frontend/src/components/README.md)

--- a/TODO.md
+++ b/TODO.md
@@ -27,12 +27,18 @@ Architecture:
  
 Environment:    
 - [ ] Tilt Setup: 
-    - [ ] Convert docker-compose over
-    - [ ] Be able to access web-frontend 
-    - [ ] Public-api run and web-frontend can hit it 
+    - [x] Convert docker-compose over
+    - [x] Be able to access web-frontend 
+    - [x] Public-api run 
+    - [x] web-frontend can hit public-api 
     - [x] Public-api initialized api-store
+    - [x] Add sg service
+    - [ ] Convert to using DNS names -- finally connected the web-frontend 
+        and public-api by opening public-api -- need to make it private 
 
 Public-API: 
+- [ ] Health endpoint (https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/)
+- [ ] Graceful shutdown (https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/)
 - [ ] Request JSON-to-Struct Mapping
 - [ ] Backend Go Linter
 - [ ] API Service Test Pattern

--- a/Tiltfile
+++ b/Tiltfile
@@ -8,14 +8,17 @@
 
 docker_build('sg/public-api-image', context='services/public-api')
 docker_build('sg/web-frontend-image', context='services/web-frontend')
+docker_build('sg/sg-image', context='services/sg')
 
 k8s_yaml("services/api-store/tilt.yaml")
 k8s_yaml("services/public-api/tilt.yaml")
 k8s_yaml("services/web-frontend/tilt.yaml")
+k8s_yaml("services/sg/tilt.yaml")
 
 k8s_resource('sg-api-store')
-k8s_resource('sg-public-api', port_forwards='9001', resource_deps=['sg-api-store'])
-k8s_resource('sg-web-frontend', port_forwards='9002', resource_deps=['sg-public-api'])
+k8s_resource('sg-sg')
+k8s_resource('sg-public-api', resource_deps=['sg-api-store', 'sg-sg'])
+k8s_resource('sg-web-frontend', resource_deps=['sg-public-api'])
 
 # 1. Docker Images
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,8 @@
+# -*- mode: Python -*-
+
+# Once working, add in
+# For more on Extensions, see: https://docs.tilt.dev/extensions.html
+# load('ext://restart_process', 'docker_build_with_restart')
+
+docker_compose('docker-compose.yml')
+

--- a/Tiltfile
+++ b/Tiltfile
@@ -4,5 +4,28 @@
 # For more on Extensions, see: https://docs.tilt.dev/extensions.html
 # load('ext://restart_process', 'docker_build_with_restart')
 
-docker_compose('docker-compose.yml')
+# docker_compose('docker-compose.yml')
+
+docker_build('sg/public-api-image', context='services/public-api')
+docker_build('sg/web-frontend-image', context='services/web-frontend')
+
+k8s_yaml("services/api-store/tilt.yaml")
+k8s_yaml("services/public-api/tilt.yaml")
+k8s_yaml("services/web-frontend/tilt.yaml")
+
+k8s_resource('sg-api-store')
+k8s_resource('sg-public-api', port_forwards='9001', resource_deps=['sg-api-store'])
+k8s_resource('sg-web-frontend', port_forwards='9002', resource_deps=['sg-public-api'])
+
+
+# 1. Docker Images
+
+# 2. Kubernetes Service YAMLs
+# services = ['api-store','public-api','web-frontend',]
+# kubes = ["./services/{service}/tilt.yaml".format(service = s) for s in services]
+# k8s_yaml(kubes)
+
+# 3. Tilt Resources
+# Group 1: Public API
+
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -17,7 +17,6 @@ k8s_resource('sg-api-store')
 k8s_resource('sg-public-api', port_forwards='9001', resource_deps=['sg-api-store'])
 k8s_resource('sg-web-frontend', port_forwards='9002', resource_deps=['sg-public-api'])
 
-
 # 1. Docker Images
 
 # 2. Kubernetes Service YAMLs

--- a/services/api-store/tilt.yaml
+++ b/services/api-store/tilt.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: sg-api-store-config
+  labels:
+    app: sg-api-store
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: postgres-user
+  POSTGRES_PASSWORD: secret
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: sg-api-store-volume
+  labels:
+    type: local
+    app: api-store
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/data"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: sg-api-store-claim
+  labels:
+    app: sg-api-store
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: sg-api-store
+spec:
+  selector:
+    matchLabels:
+      app: sg-api-store
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sg-api-store
+    spec:
+      containers:
+        - name: sg-api-store
+          image: postgres:12.3
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: sg-api-store-config
+          volumeMounts:
+            - mountPath: /data
+              name: postgredb
+      volumes:
+        - name: postgredb
+          persistentVolumeClaim:
+            claimName: sg-api-store-claim
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: sg-api-store
+  labels:
+    app: sg-api-store
+spec:
+  type: NodePort
+  ports:
+    - port: 5432
+  selector:
+    app: sg-api-store

--- a/services/api-store/tilt.yaml
+++ b/services/api-store/tilt.yaml
@@ -47,7 +47,6 @@ spec:
   selector:
     matchLabels:
       app: sg-api-store
-  replicas: 1
   template:
     metadata:
       labels:

--- a/services/public-api/Dockerfile
+++ b/services/public-api/Dockerfile
@@ -15,4 +15,4 @@ COPY db/migrations ./migrations
 COPY . .
 
 RUN go build -mod=vendor -o main ./api/api.go
-CMD ["./main", "172.18.0.4"]
+CMD ["./main", "sg-public-api", "sg-api-store"]

--- a/services/public-api/Dockerfile
+++ b/services/public-api/Dockerfile
@@ -14,5 +14,7 @@ COPY db/migrations ./migrations
 
 COPY . .
 
+EXPOSE 8000
+
 RUN go build -mod=vendor -o main ./api/api.go
 CMD ["./main", "sg-public-api", "sg-api-store"]

--- a/services/public-api/Makefile
+++ b/services/public-api/Makefile
@@ -1,5 +1,2 @@
-run:
-	go run ./api/api.go localhost
-
 build:
 	go build -o main ./api/api.go

--- a/services/public-api/api/api.go
+++ b/services/public-api/api/api.go
@@ -20,6 +20,7 @@ func main() {
 		panic("Store not defined")
 	}
 
+	// Store host set to sg-api-store
 	h := handlers.NewAPIHandler(store, 40)
 	defer h.Close()
 
@@ -31,17 +32,17 @@ func main() {
 	//	And confirm an overlap
 
 	router := gin.Default()
-
-	// TODO: Must change origin
 	router.Use(cors.New(cors.Config{
 		AllowCredentials: true,
 		AllowOriginFunc: func(origin string) bool {
+			// TODO: Must change origin
 			// Local web-frontend: http://localhost:3000
 			// Container web-frontend: http://localhost
+			// Tilt: http://localhost:8000
 			isLocal := origin == "http://localhost:3000"
 			isContainer := origin == "http://localhost"
-
-			return isLocal || isContainer
+			isTilt := origin == "http://localhost:8000"
+			return isLocal || isContainer || isTilt
 		},
 	}))
 
@@ -52,6 +53,6 @@ func main() {
 	v1.PUT("/silos/:silo_id", h.UpdateSilo)
 	v1.DELETE("/silos/:silo_id", h.DeleteSilo)
 
-	origin := fmt.Sprintf("%s:%d", host, 8000)
+	origin := fmt.Sprintf(":%d", 8000)
 	router.Run(origin) // Public API IP:Port
 }

--- a/services/public-api/api/api.go
+++ b/services/public-api/api/api.go
@@ -11,18 +11,16 @@ import (
 
 func main() {
 	// Pass in target IP of Public API service. Localhost for individually run, 172.17.0.2 for container
-	ip := os.Args[1]
-	if ip == "" {
-		panic("IP not defined")
+	host := os.Args[1]
+	if host == "" {
+		panic("Host not defined")
+	}
+	store := os.Args[2]
+	if store == "" {
+		panic("Store not defined")
 	}
 
-	host := "172.18.0.3" // Postgres IP:Port
-	if ip == "localhost" {
-		// If host is localhost then use `stevenelleman` db
-		host = ip
-	}
-
-	h := handlers.NewAPIHandler(host, 40)
+	h := handlers.NewAPIHandler(store, 40)
 	defer h.Close()
 
 	// TODO: need authz middleware to convert cookie into faceted identity list.
@@ -33,6 +31,8 @@ func main() {
 	//	And confirm an overlap
 
 	router := gin.Default()
+
+	// TODO: Must change origin
 	router.Use(cors.New(cors.Config{
 		AllowCredentials: true,
 		AllowOriginFunc: func(origin string) bool {
@@ -52,6 +52,6 @@ func main() {
 	v1.PUT("/silos/:silo_id", h.UpdateSilo)
 	v1.DELETE("/silos/:silo_id", h.DeleteSilo)
 
-	origin := fmt.Sprintf("%s:%d", ip, 8000)
+	origin := fmt.Sprintf("%s:%d", host, 8000)
 	router.Run(origin) // Public API IP:Port
 }

--- a/services/public-api/controller/sgclient/client.go
+++ b/services/public-api/controller/sgclient/client.go
@@ -10,7 +10,7 @@ import (
 
 // TODO: Move to central constant config
 const (
-	address = "172.18.0.5:50051"
+	address = "sg-sg:8001"
 )
 
 type SGClient struct {

--- a/services/public-api/db/db.go
+++ b/services/public-api/db/db.go
@@ -11,7 +11,7 @@ const (
 	port     = "5432"
 	user     = "postgres-user"
 	password = "secret"
-	name     = "postgres"
+	name     = "postgresdb"
 )
 
 func InitDb(host string, conns int) *sql.DB {

--- a/services/public-api/handlers/silos.go
+++ b/services/public-api/handlers/silos.go
@@ -9,12 +9,11 @@ import (
 func (h *APIHandler) ListSilos(c *gin.Context) {
 	silos, err := h.Controller.ListSilos()
 	if err != nil {
-		ReturnError(c, 400, err)
 		// TODO: Someone is going to forget to put the return statement - how to refactor to avoid?
-		return
+		ReturnError(c, 400, err)
+	} else {
+		ReturnJSONList(c, 200, silos)
 	}
-	ReturnJSONList(c, 200, silos)
-	return
 }
 
 func (h *APIHandler) GetSilo(c *gin.Context) {

--- a/services/public-api/tilt.yaml
+++ b/services/public-api/tilt.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sg-public-api
+  labels:
+    app: sg-public-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sg-public-api
+  template:
+    metadata:
+      labels:
+        app: sg-public-api
+    spec:
+      containers:
+        - name: sg-public-api
+          image: sg/public-api-image
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sg-public-api-svc
+spec:
+  type: NodePort
+  selector:
+    app: sg-public-api
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/services/public-api/tilt.yaml
+++ b/services/public-api/tilt.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: sg-public-api
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: sg-public-api

--- a/services/public-api/tilt.yaml
+++ b/services/public-api/tilt.yaml
@@ -24,12 +24,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: sg-public-api-svc
+  name: sg-public-api
+  labels:
+    app: sg-public-api
 spec:
-  type: NodePort
+  type: LoadBalancer
+  ports:
+    - port: 8000
   selector:
     app: sg-public-api
-  ports:
-    - protocol: TCP
-      port: 8000
-      targetPort: 8000

--- a/services/sg/Dockerfile
+++ b/services/sg/Dockerfile
@@ -8,7 +8,10 @@ COPY go.sum .
 
 # Copy local vendor file
 COPY vendor ./vendor
+# TODO: Is this copy necessary?
 COPY . .
+
+EXPOSE 8001
 
 RUN go build -mod=vendor -o main main.go
 CMD ["./main"]

--- a/services/sg/main.go
+++ b/services/sg/main.go
@@ -10,8 +10,9 @@ import (
 	"google.golang.org/grpc"
 )
 
+// TODO: Move to central constant location
 const (
-	port = ":50051"
+	port = ":8001"
 )
 
 func sayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
@@ -19,7 +20,7 @@ func sayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) 
 }
 
 func main() {
-	fmt.Println("Listen on 50051")
+	fmt.Printf("Listen on %s\n", port)
 	lis, err := net.Listen("tcp", port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)

--- a/services/sg/tilt.yaml
+++ b/services/sg/tilt.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sg-sg
+  labels:
+    app: sg-sg
+spec:
+  selector:
+    matchLabels:
+      app: sg-sg
+  template:
+    metadata:
+      labels:
+        app: sg-sg
+    spec:
+      containers:
+        - name: sg-sg
+          image: sg/sg-image
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sg-sg
+  labels:
+    app: sg-sg
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8001
+  selector:
+    app: sg-sg

--- a/services/source-store/README.md
+++ b/services/source-store/README.md
@@ -1,0 +1,1 @@
+# Source-Store

--- a/services/web-frontend/package.json
+++ b/services/web-frontend/package.json
@@ -24,7 +24,7 @@
     "typescript": "^3.9.5"
   },
   "scripts": {
-    "start": "REACT_APP_HOST=\"sg-public-api\" react-scripts start",
+    "start": "REACT_APP_HOST=\"localhost\" react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/services/web-frontend/package.json
+++ b/services/web-frontend/package.json
@@ -24,7 +24,7 @@
     "typescript": "^3.9.5"
   },
   "scripts": {
-    "start": "REACT_APP_HOST=\"localhost\" react-scripts start",
+    "start": "REACT_APP_HOST=\"sg-public-api\" react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/services/web-frontend/src/App.tsx
+++ b/services/web-frontend/src/App.tsx
@@ -20,10 +20,11 @@ class App extends React.Component<any, StateType> {
   constructor(props: any) {
     super(props);
 
-    const host = process.env.REACT_APP_HOST;
+    const host = process.env.REACT_APP_HOST || "localhost";
+    const protocol = "http";
     const port = 8000;
     this.state = {
-      client: new Client(`${host}:${port}`), // Public API IP:Port
+      client: new Client(protocol, host, port), // Public API IP:Port
     };
   }
 

--- a/services/web-frontend/src/client/index.ts
+++ b/services/web-frontend/src/client/index.ts
@@ -10,25 +10,14 @@ import {
 } from './constants';
 import { isValidUrl } from '../utils';
 
-/*
-   TODO:
-    - Authz context. Must include cookie(s) in request.
-    - Test fetch logic
-    - Arg/opts handler
-    - Make a ts Client interface
-    - Make object types
-*/
-
 export class Client {
-  // Prop Types
-  origin: string;
   protocol: string;
+  origin: string;
   port: number;
 
-  // Constructor
-  constructor(origin: string, protocol: string, port:number) {
-    this.origin = origin;
+  constructor(protocol: string, origin: string, port:number) {
     this.protocol = protocol;
+    this.origin = origin;
     this.port = port
     // TODO: include cookies when instantiated.
   }
@@ -44,8 +33,7 @@ export class Client {
   //  - Better stateHandler type
   //  - Pass in a generic error action in App
   public request(verb: string, route: string, args: any, opts: any, stateHandler: any, errorHandler: any) {
-    //const url = `${this.protocol}://${this.origin}:${this.port}/${route}`;
-    const url = `${this.origin}:${this.port}/${route}`;
+    const url = `${this.protocol}://${this.origin}:${this.port}/${route}`;
     if (!isValidUrl(url)) {
       return Client.emitError(`invalid url: ${url}`);
     }

--- a/services/web-frontend/src/client/index.ts
+++ b/services/web-frontend/src/client/index.ts
@@ -22,10 +22,14 @@ import { isValidUrl } from '../utils';
 export class Client {
   // Prop Types
   origin: string;
+  protocol: string;
+  port: number;
 
   // Constructor
-  constructor(origin: string) {
+  constructor(origin: string, protocol: string, port:number) {
     this.origin = origin;
+    this.protocol = protocol;
+    this.port = port
     // TODO: include cookies when instantiated.
   }
 
@@ -40,7 +44,8 @@ export class Client {
   //  - Better stateHandler type
   //  - Pass in a generic error action in App
   public request(verb: string, route: string, args: any, opts: any, stateHandler: any, errorHandler: any) {
-    const url = `http://${this.origin}/${route}`;
+    //const url = `${this.protocol}://${this.origin}:${this.port}/${route}`;
+    const url = `${this.origin}:${this.port}/${route}`;
     if (!isValidUrl(url)) {
       return Client.emitError(`invalid url: ${url}`);
     }

--- a/services/web-frontend/src/ui/components/reuseable/CreateView.tsx
+++ b/services/web-frontend/src/ui/components/reuseable/CreateView.tsx
@@ -10,6 +10,7 @@ type PropsType = {
 export class CreateView extends React.Component<PropsType> {
   render() {
     const { type } = this.props;
+
     return <div>
       {` ${type} woot woot!`}
     </div>;

--- a/services/web-frontend/tilt.yaml
+++ b/services/web-frontend/tilt.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sg-web-frontend
+spec:
+  selector:
+    matchLabels:
+      app: sg-web-frontend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sg-web-frontend
+    spec:
+      containers:
+        - name: sg-web-frontend
+          image: sg/web-frontend-image
+          imagePullPolicy: Never
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sg-web-frontend-svc
+  labels:
+    app: sg-web-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: sg-web-frontend
+  ports:
+    - protocol: "TCP"
+      port: 80
+      targetPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: sg-web-frontend-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /v1
+            backend:
+              serviceName: sg-web-frontend-svc
+              servicePort: 3000

--- a/services/web-frontend/tilt.yaml
+++ b/services/web-frontend/tilt.yaml
@@ -21,27 +21,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: sg-web-frontend-svc
+  name: sg-web-frontend
+  namespace: default
   labels:
     app: sg-web-frontend
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   selector:
     app: sg-web-frontend
   ports:
     - protocol: "TCP"
       port: 80
       targetPort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: sg-web-frontend-ingress
-spec:
-  rules:
-    - http:
-        paths:
-          - path: /v1
-            backend:
-              serviceName: sg-web-frontend-svc
-              servicePort: 3000

--- a/services/web-frontend/tilt.yaml
+++ b/services/web-frontend/tilt.yaml
@@ -7,7 +7,6 @@ spec:
   selector:
     matchLabels:
       app: sg-web-frontend
-  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Terms
Tilt: Kubernetes Orchestrator (https://docs.tilt.dev/) 

## What 
Replace docker compose with Tilt. Also added `sg` service. 

## How 
- Make associated k8s objects for `api-store`, `public-api`, `sg`, and `web-frontend` services. 
- Ensure that all networking between services works -- currently this means several services (`public-api`, `sg`) have public ips -- will need to fix this before deploying to production.  

## Why 
Hella fast once it's configured properly. Docker image layers are cached s.t. only changed layers are rebuilt and rerun. After cached it takes ~30 seconds to run everything (and ~5 seconds to rebuild an updated service). 

## Tasks 

## Notes to Reviewers 

## Meta 